### PR TITLE
Allow reads from /dev/urandom above SSIZE_MAX

### DIFF
--- a/randombytes.c
+++ b/randombytes.c
@@ -137,19 +137,16 @@ static int randombytes_linux_wait_for_entropy(int device)
 static int randombytes_linux_randombytes_urandom(void *buf, size_t n)
 {
 	int fd;
-	size_t offset = 0;
+	size_t offset = 0, count;
 	ssize_t tmp;
 	do {
 		fd = open("/dev/urandom", O_RDONLY);
 	} while (fd == -1 && errno == EINTR);
 	if (randombytes_linux_wait_for_entropy(fd) == -1) return -1;
 
-	if (n > SSIZE_MAX) {
-		errno = EINVAL;
-		return -1;
-	}
 	while (n > 0) {
-		tmp = read(fd, (char *)buf + offset, n);
+		count = n <= SSIZE_MAX ? n : SSIZE_MAX;
+		tmp = read(fd, (char *)buf + offset, count);
 		if (tmp == -1 && (errno == EAGAIN || errno == EINTR)) {
 			continue;
 		}

--- a/test.c
+++ b/test.c
@@ -1,4 +1,5 @@
 #include "randombytes.h"
+#include <errno.h>
 #include <inttypes.h>
 #include <stdio.h>
 
@@ -11,7 +12,7 @@ int main(void)
 
     ret = randombytes(buf, sizeof(buf));
     if (ret != 0) {
-        printf("Error in `randombytes`");
+        printf("Error in `randombytes`: %d\n", errno);
         return 1;
     }
     for (i = 0; i < sizeof(buf); ++i) {


### PR DESCRIPTION
Before this change, reads from `/dev/urandom` may result in unspecified behaviour when the user supplies a buffer length that is greater than `SSIZE_LEN`. (https://linux.die.net/man/2/read)

This PR changes the way we read from `/dev/urandom` to read in chunks of at most `SSIZE_MAX` bytes.