### PR TITLE
Add #define _GNU_SOURCE to randombytes.h

### DIFF
--- a/randombytes.c
+++ b/randombytes.c
@@ -1,3 +1,10 @@
+// In the case that are compiling on linux, we need to define _GNU_SOURCE
+// *before* randombytes.h is included. Otherwise SYS_getrandom will not be
+// declared.
+#if defined(__linux__)
+# define _GNU_SOURCE
+#endif /* defined(__linux__) */
+
 #include "randombytes.h"
 
 #if defined(_WIN32)
@@ -9,7 +16,6 @@
 
 #if defined(__linux__)
 /* Linux */
-# define _GNU_SOURCE
 # include <assert.h>
 # include <errno.h>
 # include <fcntl.h>

--- a/randombytes.h
+++ b/randombytes.h
@@ -5,7 +5,6 @@
 /* Load size_t on windows */
 #include <CRTDEFS.H>
 #else
-#include <sys/syscall.h>
 #include <unistd.h>
 #endif /* _WIN32 */
 


### PR DESCRIPTION
On compilation on Linux with the `getrandom` system call, the compiler throws a warning, because `SYS_getrandom` is defined implicitly. This was because the `#include`s in `randombytes.h` do not set `_GNU_SOURCE` accordingly. So `_GNU_SOURCE` is defined *after* `unistd.h` is included for the first time.

This PR adds `_GNU_SOURCE` to `randombytes.h` to fix this issue.