### PR TITLE
Add support for musl-libc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,19 @@
 language: c
-script: make
 os:
   - linux
   - osx
 compiler:
   - clang
   - gcc
+matrix:
+  include:
+    - os: linux
+      compiler: musl-gcc
+      addons:
+        apt:
+          packages:
+            - musl
+            - musl-dev
+            - musl-tools
 script:
   - make && make check

--- a/randombytes.c
+++ b/randombytes.c
@@ -16,10 +16,15 @@
 
 #if defined(__linux__)
 /* Linux */
+// We would need to include <linux/random.h>, but not every target has access
+// to the linux headers. We only need RNDGETENTCNT, so we instead inline it.
+// RNDGETENTCNT is originally defined in `include/uapi/linux/random.h` in the
+// linux repo.
+# define RNDGETENTCNT 0x80045200
+
 # include <assert.h>
 # include <errno.h>
 # include <fcntl.h>
-# include <linux/random.h>
 # include <poll.h>
 # include <stdint.h>
 # include <sys/ioctl.h>


### PR DESCRIPTION
Musl-gcc fails on compilation, because it cannot find `sys/random.h`. From this header file, we only use `RNDGETENTCNT`, which is `0`. This PR edits the code s.t. we do not have to rely on the presence of the linux headers anymore. Instead, we define this little piece of the linux headers inline. (Based on a [StackOverflow answer](https://stackoverflow.com/a/11576521/5207081).

This PR also adds musl-libc to travis as a build target.