### PR TITLE
emscripten: Handle missing crypto support

### DIFF
--- a/randombytes.c
+++ b/randombytes.c
@@ -186,8 +186,8 @@ static int randombytes_bsd_randombytes(void *buf, size_t n)
 #if defined(__EMSCRIPTEN__)
 static int randombytes_js_randombytes_nodejs(void *buf, size_t n) {
 	int ret = EM_ASM_INT({
-		const crypto = require('crypto');
 		try {
+			const crypto = require('crypto');
 			writeArrayToMemory(crypto.randomBytes($1), $0);
 			return 0;
 		} catch (error) {


### PR DESCRIPTION
According to the Node docs

> [It is possible for Node.js to be built without including support for the `crypto` module. In such cases, calling `require('crypto')` will result in an error being thrown.](https://nodejs.org/api/crypto.html#crypto_determining_if_crypto_support_is_unavailable)

So I just moved the `require` inside of the try block so randombytes will return -1 instead of bringing down the caller in that case.