### PR TITLE
/dev/urandom: Check the return value from open()

### DIFF
--- a/randombytes.c
+++ b/randombytes.c
@@ -156,6 +156,7 @@ static int randombytes_linux_randombytes_urandom(void *buf, size_t n)
 	do {
 		fd = open("/dev/urandom", O_RDONLY);
 	} while (fd == -1 && errno == EINTR);
+	if (fd == -1) return -1;
 	if (randombytes_linux_wait_for_entropy(fd) == -1) return -1;
 
 	while (n > 0) {


### PR DESCRIPTION
This PR changes the `/dev/urandom` implemantation such that the return value from `open()` is now checked. If it is `-1`, we return.

Note that we do not need to set `errno`, because `open()` has set it for us.