### PR TITLE
emscripten: Change ENOPKG to ENOSYS

### DIFF
--- a/randombytes.c
+++ b/randombytes.c
@@ -209,7 +209,7 @@ static int randombytes_js_randombytes_nodejs(void *buf, size_t n) {
 		errno = EINVAL;
 		return -1;
 	case -2:
-		errno = ENOPKG;
+		errno = ENOSYS;
 		return -1;
 	}
 	assert(false); // Unreachable


### PR DESCRIPTION
`ENOPKG` is linux-specific, but we want to support more than that. This PR changes the `ENOPKG` error to `ENOSYS` (meaning functionality is not available), but is more generic.