### PR TITLE
linux: Implement /proc/.../entropy_avail fallback

### DIFF
--- a/randombytes_test.c
+++ b/randombytes_test.c
@@ -76,10 +76,12 @@ static void test_getrandom_interrupted(void) {
 }
 
 static void test_issue_17(void) {
-	uint8_t buf[20] = {};
-	const int ret = randombytes(buf, sizeof(buf));
-	assert(ret == -1);
-	assert(errno = ENOTTY);
+	uint8_t buf1[20] = {}, buf2[sizeof(buf1)] = {};
+	const int ret1 = randombytes(buf1, sizeof(buf1));
+	const int ret2 = randombytes(buf2, sizeof(buf2));
+	assert(ret1 == 0);
+	assert(ret2 == 0);
+	assert(memcmp(buf1, buf2, sizeof(buf1)) != 0);
 }
 
 // ======== Mock OS functions to simulate uncommon behavior ========


### PR DESCRIPTION
This commit implements a fallback for the /dev/urandom entropy
estimate retrieval, for when the ioctl on /dev/random fails (see
also issue #17). We still poll on /dev/random, but instead of
ioctl'ing, we read from /proc/sys/kernel/random/entropy_avail to
get the entropy count.

This PR updates test_issue_17 accordingly.

Fixes issue #17.