### PR TITLE
Declare __{wrap,real}_syscall in correct #ifdef scope

### DIFF
--- a/randombytes_test.c
+++ b/randombytes_test.c
@@ -29,11 +29,14 @@ static void padto(const char c, const size_t curlen, const size_t len) {
 
 // ======== Forward declarations needed for mocked functions ========
 
+#if defined(__linux__) && defined(SYS_getrandom)
+int __wrap_syscall(int n, char *buf, size_t buflen, int flags);
+int __real_syscall(int n, char *buf, size_t buflen, int flags);
+#endif /* defined(__linux__) && defined(SYS_getrandom) */
+
 #if defined(__linux__) && !defined(SYS_getrandom)
 int __wrap_ioctl(int fd, int code, int* ret);
 int __real_ioctl(int fd, int code, int* ret);
-int __wrap_syscall(int n, char *buf, size_t buflen, int flags);
-int __real_syscall(int n, char *buf, size_t buflen, int flags);
 #endif /* defined(__linux__) && !defined(SYS_getrandom) */
 
 // ======== Test definitions ========


### PR DESCRIPTION
Before, the functions `__wrap_syscall` and `__real_syscall` were undeclared in the `#if defined(__linux__) && defined(SYS_getrandom)` scope. This PR moves the declaration of these functions to the correct `#ifdef` scope.