### PR TITLE
Change compilation to gnu99 to fix emscripten

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CFLAGS := -g -O2 -m64 -std=c99 \
+CFLAGS := -g -O2 -m64 -std=gnu99 \
 	-Wall -Wextra -Wshadow -Wpointer-arith -Wcast-qual -Wformat \
 	-Wformat-security -Werror=format-security -Wstrict-prototypes \
 	-D_FORTIFY_SOURCE=2 -fPIC -fno-strict-overflow


### PR DESCRIPTION
This PR changes the default compilation target to `-std=gnu99` instead of `-std=c99`. Apparently, something in the emscripten system has changed to require this. For other targets, `-std=c99` should still work.