### PR TITLE
travis: Add arm64 architecture to build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,23 @@ os:
 compiler:
   - clang
   - gcc
+arch:
+  - amd64
+  - arm64
 matrix:
   include:
     - os: linux
       compiler: musl-gcc
+      arch: amd64
+      addons:
+        apt:
+          packages:
+            - musl
+            - musl-dev
+            - musl-tools
+    - os: linux
+      compiler: musl-gcc
+      arch: arm64
       addons:
         apt:
           packages:


### PR DESCRIPTION
Travis now support compilation on arm64 targets. More build targets is more better, so this PR adds the arm64 target to the build matrix.