### PR TITLE
Adds support for GNU/Hurd and GNU/kFreeBSD

### DIFF
--- a/randombytes.c
+++ b/randombytes.c
@@ -174,6 +174,9 @@ static int randombytes_linux_wait_for_entropy(int device)
 		strategy = PROC;
 		// Open the entropy count file
 		proc_file = fopen("/proc/sys/kernel/random/entropy_avail", "r");
+		if (proc_file == NULL) {
+			return -1;
+		}
 	} else if (retcode != 0) {
 		// Unrecoverable ioctl error
 		return -1;

--- a/randombytes.c
+++ b/randombytes.c
@@ -1,9 +1,9 @@
 // In the case that are compiling on linux, we need to define _GNU_SOURCE
 // *before* randombytes.h is included. Otherwise SYS_getrandom will not be
 // declared.
-#if defined(__linux__)
+#if defined(__linux__) || defined(__GNU__)
 # define _GNU_SOURCE
-#endif /* defined(__linux__) */
+#endif /* defined(__linux__) || defined(__GNU__) */
 
 #include "randombytes.h"
 
@@ -18,7 +18,12 @@
 #include <stdlib.h>
 #endif
 
-#if defined(__linux__)
+/* kFreeBSD */
+#if defined(__FreeBSD_kernel__) && defined(__GLIBC__)
+# define GNU_KFREEBSD
+#endif
+
+#if defined(__linux__) || defined(__GNU__) || defined(GNU_KFREEBSD)
 /* Linux */
 // We would need to include <linux/random.h>, but not every target has access
 // to the linux headers. We only need RNDGETENTCNT, so we instead inline it.
@@ -33,10 +38,10 @@
 # include <stdint.h>
 # include <stdio.h>
 # include <sys/ioctl.h>
-# if defined(__linux__) && defined(__GLIBC__) && ((__GLIBC__ > 2) || (__GLIBC_MINOR__ > 24))
+# if (defined(__linux__) || defined(__GNU__)) && defined(__GLIBC__) && ((__GLIBC__ > 2) || (__GLIBC_MINOR__ > 24))
 #  define USE_GLIBC
 #  include <sys/random.h>
-# endif /* defined(__linux__) && defined(__GLIBC__) && ((__GLIBC__ > 2) || (__GLIBC_MINOR__ > 24)) */
+# endif /* (defined(__linux__) || defined(__GNU__)) && defined(__GLIBC__) && ((__GLIBC__ > 2) || (__GLIBC_MINOR__ > 24)) */
 # include <sys/stat.h>
 # include <sys/syscall.h>
 # include <sys/types.h>
@@ -47,7 +52,7 @@
 #  define SSIZE_MAX (SIZE_MAX / 2 - 1)
 # endif /* defined(SSIZE_MAX) */
 
-#endif /* defined(__linux__) */
+#endif /* defined(__linux__) || defined(__GNU__) || defined(GNU_KFREEBSD) */
 
 
 #if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
@@ -55,6 +60,10 @@
 # include <sys/param.h>
 # if defined(BSD)
 #  include <stdlib.h>
+# endif
+/* GNU/Hurd defines BSD in sys/param.h which causes problems later */
+# if defined(__GNU__)
+#  undef BSD
 # endif
 #endif
 
@@ -93,7 +102,7 @@ static int randombytes_wasi_randombytes(void *buf, size_t n) {
 }
 #endif /* defined(__wasi__) */
 
-#if defined(__linux__) && (defined(USE_GLIBC) || defined(SYS_getrandom))
+#if (defined(__linux__) || defined(__GNU__)) && (defined(USE_GLIBC) || defined(SYS_getrandom))
 # if defined(USE_GLIBC)
 // getrandom is declared in glibc.
 # elif defined(SYS_getrandom)
@@ -123,10 +132,11 @@ static int randombytes_linux_randombytes_getrandom(void *buf, size_t n)
 	assert(n == 0);
 	return 0;
 }
-#endif // defined(__linux__) && (defined(USE_GLIBC) || defined(SYS_getrandom))
+#endif /* (defined(__linux__) || defined(__GNU__)) && (defined(USE_GLIBC) || defined(SYS_getrandom)) */
 
+#if (defined(__linux__) || defined(GNU_KFREEBSD)) && !defined(SYS_getrandom)
 
-#if defined(__linux__) && !defined(SYS_getrandom)
+# if defined(__linux__)
 static int randombytes_linux_read_entropy_ioctl(int device, int *entropy)
 {
 	return ioctl(device, RNDGETENTCNT, entropy);
@@ -235,6 +245,7 @@ static int randombytes_linux_wait_for_entropy(int device)
 	}
 	return retcode;
 }
+# endif /* defined(__linux__) */
 
 
 static int randombytes_linux_randombytes_urandom(void *buf, size_t n)
@@ -246,7 +257,9 @@ static int randombytes_linux_randombytes_urandom(void *buf, size_t n)
 		fd = open("/dev/urandom", O_RDONLY);
 	} while (fd == -1 && errno == EINTR);
 	if (fd == -1) return -1;
+# if defined(__linux__)
 	if (randombytes_linux_wait_for_entropy(fd) == -1) return -1;
+# endif
 
 	while (n > 0) {
 		count = n <= SSIZE_MAX ? n : SSIZE_MAX;
@@ -310,7 +323,7 @@ int randombytes(void *buf, size_t n)
 #if defined(__EMSCRIPTEN__)
 # pragma message("Using crypto api from NodeJS")
 	return randombytes_js_randombytes_nodejs(buf, n);
-#elif defined(__linux__)
+#elif defined(__linux__) || defined(__GNU__) || defined(GNU_KFREEBSD)
 # if defined(USE_GLIBC)
 #  pragma message("Using getrandom function call")
 	/* Use getrandom system call */


### PR DESCRIPTION
I noticed that the library [fails on two niche GNU flavors](https://buildd.debian.org/status/package.php?p=libmobi&suite=sid): GNU/Hurd and GNU/kFreeBSD.
This PR is proposed fix. I tested that it works on both systems.
In case you want to handle this some other way, these are my observations.

Fixing GNU/Hurd just requires that it is treated as linux. It is detected by `__GNU__` macro. The only tricky point is that hurd defines `BSD` macro in its `sys/param.h` header. So I [unset it](https://github.com/bfabiszewski/randombytes/blob/9fcd3f90b20db1d3a88c5855a7741a21bdbbc200/randombytes.c#L64). As it has glibc it finally uses `getrandom` function call. 

GNU/kFreeBSD uses BSD kernel but does not have `arc4random` like other BSD family members. It does not have `SYS_getrandom` system call either.  It has `getrandom` function but it is just unusable stub (linker spits: "warning: getrandom is not implemented and will always fail"). The only option left is `/dev/urandom` but we have to skip linux-specific part. I skipped whole `/dev/random` polling and entropy related stuff as this is basically what libsodium does for systems other than linux.

BTW. Pragma `message` is treated as warning by clang and it breaks `-Werror` builds. In my repo [I wrapped it in a macro](https://github.com/bfabiszewski/libmobi/blob/aac5b1f578b284b2f886d6d25cde22a33d8534f8/src/randombytes.c#L35) so that I can enable it only when I need to debug.

Thanks for the library!